### PR TITLE
Note about middleware order and ETags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ You will also need to add a middleware class to listen in on responses:
     MIDDLEWARE_CLASSES = (
         ...
         'corsheaders.middleware.CorsMiddleware',
+        'django.middleware.common.CommonMiddleware',
         ...
     )
+
+Note that `CorsMiddleware` needs to come before Django's `CommonMiddleware` if you are using Django's `USE_ETAGS = True` setting, otherwise the CORS headers will be lost from the 304 not-modified responses, causing errors in some browsers.
 
 ## Configuration ##
 


### PR DESCRIPTION
It's not obvious but if middleware is not in this order it leads to errors in Chrome when trying to do cross-domain XHR with ETags.

See here for info http://stackoverflow.com/questions/11933626/access-control-allow-origin-header-not-working-what-am-i-doing-wrong

Basically the 304 response must have the CORS headers, but `CommonMiddleware` replaces the existing response with a new `HttpResponseNotModified` so they get lost unless `CorsMiddleware` processes the request later.
