### PR TITLE
Better regex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Add hosts that are allowed to do cross-site requests to `CORS_ORIGIN_WHITELIST` 
 
     Example:
 
-        CORS_ORIGIN_REGEX_WHITELIST = ('^http?://(\w+\.)?google\.com$', )
+        CORS_ORIGIN_REGEX_WHITELIST = ('^(https?://)?(\w+\.)?google\.com$', )
 
 
     Default:


### PR DESCRIPTION
The regex in the example is sort of wrong.
For example, it would match 'htt://google.com' and wouldn't match 'www.google.com'.
