### PR TITLE
Regex matches will never be evaluated since url.netloc will not be in settings.CORS_ORIGIN_WHITELIST

### DIFF
--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -67,7 +67,10 @@ class CorsMiddleware(object):
         return response
 
     def origin_not_found_in_white_lists(self, origin, url):
-        return url.netloc not in settings.CORS_ORIGIN_WHITELIST and not self.regex_domain_match(origin)
+        if url.netloc not in settings.CORS_ORIGIN_WHITELIST:
+            return not self.regex_domain_match(origin)
+        else:
+            retrun False
 
     def regex_domain_match(self, origin):
         for domain_pattern in settings.CORS_ORIGIN_REGEX_WHITELIST:


### PR DESCRIPTION
Please merge and release as soon as possible.

If the first part of the and was true Python won't continue to evaluate the second part of the and clause as an optimization.
That's what is causing the problem.
