### PR TITLE
Remove django from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires=['Django >= 1.3'],
+    install_requires=[],
     tests_require=['mock >= 1.0'],
     test_suite='tests.main',
 )


### PR DESCRIPTION
Having `django` in `install_requires` makes it difficult to try out a Django release candidate or dev branch. My requirements file is something like this:

```
https://www.djangoproject.com/download/1.7c1/tarball/
django-cors-headers==0.12
```

But when I `pip install -r requirements.txt` it first installs Django 1.7c1, then `django-cors-headers` tries to bring in Django 1.6.5 from PyPI.

This unfortunately trashes my existing Django install: I see this output at some point:

```
    You have just installed Django over top of an existing
    installation, without removing it first. Because of this,
    your install may now include extraneous files from a
    previous version that have since been removed from
    Django. This is known to cause a variety of problems. You
    should manually remove the

    /home/paul/.virtualenvs/api3/lib/python2.7/site-packages/django

    directory and re-install Django.
```

For reference, other Django packages don't specify a requirement on Django for installation, and I think this is the correct thing to do:
- https://github.com/tomchristie/django-rest-framework/blob/master/setup.py
- https://github.com/kennethreitz/dj-static/blob/master/setup.py
