### PR TITLE
Use Origin instead of * when allow all and allow credentials are both set

### DIFF
--- a/corsheaders/middleware.py
+++ b/corsheaders/middleware.py
@@ -50,7 +50,7 @@ class CorsMiddleware(object):
             if not settings.CORS_ORIGIN_ALLOW_ALL and self.origin_not_found_in_white_lists(origin, url):
                 return response
 
-            response[ACCESS_CONTROL_ALLOW_ORIGIN] = "*" if settings.CORS_ORIGIN_ALLOW_ALL else origin
+            response[ACCESS_CONTROL_ALLOW_ORIGIN] = "*" if (settings.CORS_ORIGIN_ALLOW_ALL and not settings.CORS_ALLOW_CREDENTIALS) else origin
 
             if len(settings.CORS_EXPOSE_HEADERS):
                 response[ACCESS_CONTROL_EXPOSE_HEADERS] = ', '.join(settings.CORS_EXPOSE_HEADERS)


### PR DESCRIPTION
When CORS_ALLOW_ORIGIN_ALL and CORS_ALLOW_CREDENTIALS are both true this change return the Origin and not *.
This fixes error(1) throw by browsers because \* is not a valid origin when credentials are enabled.

(1) XMLHttpRequest cannot load https://app.xxxxx.com/api/xxx/. A wildcard '*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true. Origin 'http://xxxxx.com' is therefore not allowed access.
