### PR TITLE
CORB: Adding the ACCESS control headers for all methods

### DIFF
--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -137,11 +137,10 @@ class CorsMiddleware(MiddlewareMixin):
                 conf.CORS_EXPOSE_HEADERS
             )
 
-        if request.method == "OPTIONS":
-            response[ACCESS_CONTROL_ALLOW_HEADERS] = ", ".join(conf.CORS_ALLOW_HEADERS)
-            response[ACCESS_CONTROL_ALLOW_METHODS] = ", ".join(conf.CORS_ALLOW_METHODS)
-            if conf.CORS_PREFLIGHT_MAX_AGE:
-                response[ACCESS_CONTROL_MAX_AGE] = conf.CORS_PREFLIGHT_MAX_AGE
+        response[ACCESS_CONTROL_ALLOW_HEADERS] = ", ".join(conf.CORS_ALLOW_HEADERS)
+        response[ACCESS_CONTROL_ALLOW_METHODS] = ", ".join(conf.CORS_ALLOW_METHODS)
+        if conf.CORS_PREFLIGHT_MAX_AGE:
+            response[ACCESS_CONTROL_MAX_AGE] = conf.CORS_PREFLIGHT_MAX_AGE
 
         return response
 


### PR DESCRIPTION
When I am using this library in our project it is working only partially due to the changes done by Chrome recently for Cross Origin Read Blocking.  https://fetch.spec.whatwg.org/#corb

Unlike the CORS this is applied to all requests that send any data back, which can be pretty much every method.  I was able to get around it only after I commented out the OPTIONS header. 

