### PR TITLE
Fix README typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Requirements
 
 Python 3.5 to 3.8 supported.
 
-Django 1.11 to 3.0 suppported.
+Django 1.11 to 3.0 supported.
 
 Setup
 -----


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `supported` rather than `suppported`.

