### PR TITLE
Fix link to CORS wikipedia article

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ could be unintentionally opening up your site's private data to others.
 Some good resources to read on the subject are:
 
 * Julia Evans' `introductory comic <https://drawings.jvns.ca/cors/>`__
-* The `Wikipedia Page <https://en.m.wikipedia.org/wiki/Cross-origin_resource_sharing>`_
+* The `Wikipedia Page <https://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_
 * The `MDN Article <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`_
 * The `HTML5 Rocks Tutorial <https://www.html5rocks.com/en/tutorials/cors/>`_
 


### PR DESCRIPTION
Use the main article link, not the mobile one.