### PR TITLE
Remove the deprecated `providing_args` from Signal

### DIFF
--- a/src/corsheaders/signals.py
+++ b/src/corsheaders/signals.py
@@ -3,4 +3,4 @@ from django.dispatch import Signal
 # If any attached handler returns Truthy, CORS will be allowed for the request.
 # This can be used to build custom logic into the request handling when the
 # configuration doesn't work.
-check_request_enabled = Signal(providing_args=["request"])
+check_request_enabled = Signal()


### PR DESCRIPTION
See also https://code.djangoproject.com/ticket/31327