### PR TITLE
Rename "whitelist" settings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,9 +1,15 @@
 History
 =======
 
-* Rename ``CORS_ORIGIN_WHITELIST`` to ``CORS_ORIGIN_ALLOWLIST`` internally
-* Rename ``CORS_ORIGIN_WHITELIST_REGEX`` to ``CORS_ORIGIN_ALLOWLIST_REGEX`` internally
-* Support for ``CORS_ORIGIN_ALLOWLIST`` and ``CORS_ORIGIN_ALLOWLIST_REGEX`` in django settings
+* Following Django’s example in
+  `Ticket #31670 <https://code.djangoproject.com/ticket/31670>`__, the
+  following settings have been renamed:
+
+  * ``CORS_ORIGIN_WHITELIST`` -> ``CORS_ALLOWED_ORIGINS``
+  * ``CORS_ORIGIN_WHITELIST_REGEX`` -> ``CORS_ALLOWED_ORIGIN_REGEXES``
+
+  The old names will continue to work as aliases, with the new ones taking
+  precedence.
 
 3.4.0 (2020-06-19)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 History
 =======
 
+* Rename ``CORS_ORIGIN_WHITELIST`` to ``CORS_ORIGIN_ALLOWLIST`` internally
+* Rename ``CORS_ORIGIN_WHITELIST_REGEX`` to ``CORS_ORIGIN_ALLOWLIST_REGEX`` internally
+* Support for ``CORS_ORIGIN_ALLOWLIST`` and ``CORS_ORIGIN_ALLOWLIST_REGEX`` in django settings
+
+3.4.0 (2020-06-19)
+------------------
+
 * Drop Django 2.0 and 2.1 support.
 
 3.4.0 (2020-06-15)

--- a/README.rst
+++ b/README.rst
@@ -109,15 +109,15 @@ Configuration
 
 Configure the middleware's behaviour in your Django settings. You must add the
 hosts that are allowed to do cross-site requests to
-``CORS_ORIGIN_WHITELIST``, or set ``CORS_ORIGIN_ALLOW_ALL`` to ``True``
+``CORS_ORIGIN_ALLOWLIST``, or set ``CORS_ORIGIN_ALLOW_ALL`` to ``True``
 to allow all hosts.
 
 ``CORS_ORIGIN_ALLOW_ALL``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-If ``True``, the whitelist will not be used and all origins will be accepted.
+If ``True``, the allowlist will not be used and all origins will be accepted.
 Defaults to ``False``.
 
-``CORS_ORIGIN_WHITELIST``
+``CORS_ORIGIN_ALLOWLIST``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A list of origins that are authorized to make cross-site HTTP requests.
@@ -139,7 +139,7 @@ Example:
 
 .. code-block:: python
 
-    CORS_ORIGIN_WHITELIST = [
+    CORS_ORIGIN_ALLOWLIST = [
         "https://example.com",
         "https://sub.example.com",
         "http://localhost:8080",
@@ -147,19 +147,19 @@ Example:
     ]
 
 
-``CORS_ORIGIN_REGEX_WHITELIST``
+``CORS_ORIGIN_REGEX_ALLOWLIST``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A list of strings representing regexes that match Origins that are authorized
 to make cross-site HTTP requests. Defaults to ``[]``. Useful when
-``CORS_ORIGIN_WHITELIST`` is impractical, such as when you have a large number
+``CORS_ORIGIN_ALLOWLIST`` is impractical, such as when you have a large number
 of subdomains.
 
 Example:
 
 .. code-block:: python
 
-    CORS_ORIGIN_REGEX_WHITELIST = [
+    CORS_ORIGIN_REGEX_ALLOWLIST = [
         r"^https://\w+\.example\.com$",
     ]
 
@@ -286,7 +286,7 @@ For example:
 
 .. code-block:: python
 
-    CORS_ORIGIN_WHITELIST = [
+    CORS_ORIGIN_ALLOWLIST = [
         'http://read.only.com',
         'http://change.allowed.com',
     ]
@@ -377,7 +377,7 @@ of URL's, whilst allowing a normal set of origins to access *all* URL's. This
 isn't possible using just the normal configuration, but it can be achieved with
 a signal handler.
 
-First set ``CORS_ORIGIN_WHITELIST`` to the list of trusted origins that are
+First set ``CORS_ORIGIN_ALLOWLIST`` to the list of trusted origins that are
 allowed to access every URL, and then add a handler to
 ``check_request_enabled`` to allow CORS regardless of the origin for the
 unrestricted URL's. For example:

--- a/README.rst
+++ b/README.rst
@@ -107,18 +107,15 @@ in its time; thanks to every one of them.
 Configuration
 -------------
 
-Configure the middleware's behaviour in your Django settings. You must add the
-hosts that are allowed to do cross-site requests to
-``CORS_ORIGIN_ALLOWLIST``, or set ``CORS_ORIGIN_ALLOW_ALL`` to ``True``
-to allow all hosts.
+Configure the middleware's behaviour in your Django settings. You must set at
+least one of three following settings:
 
-``CORS_ORIGIN_ALLOW_ALL``
-~~~~~~~~~~~~~~~~~~~~~~~~~
-If ``True``, the allowlist will not be used and all origins will be accepted.
-Defaults to ``False``.
+* ``CORS_ALLOWED_ORIGINS``
+* ``CORS_ALLOWED_ORIGIN_REGEXES``
+* ``CORS_ORIGIN_ALLOW_ALL``
 
-``CORS_ORIGIN_ALLOWLIST``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+``CORS_ALLOWED_ORIGINS``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 A list of origins that are authorized to make cross-site HTTP requests.
 Defaults to ``[]``.
@@ -139,29 +136,44 @@ Example:
 
 .. code-block:: python
 
-    CORS_ORIGIN_ALLOWLIST = [
+    CORS_ALLOWED_ORIGINS = [
         "https://example.com",
         "https://sub.example.com",
         "http://localhost:8080",
         "http://127.0.0.1:9000"
     ]
 
+Previously this setting was called ``CORS_ORIGIN_WHITELIST``, which still works
+as an alias, with the new name takeing precedence.
 
-``CORS_ORIGIN_REGEX_ALLOWLIST``
+``CORS_ALLOWED_ORIGIN_REGEXES``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A list of strings representing regexes that match Origins that are authorized
 to make cross-site HTTP requests. Defaults to ``[]``. Useful when
-``CORS_ORIGIN_ALLOWLIST`` is impractical, such as when you have a large number
+``CORS_ALLOWED_ORIGINS`` is impractical, such as when you have a large number
 of subdomains.
 
 Example:
 
 .. code-block:: python
 
-    CORS_ORIGIN_REGEX_ALLOWLIST = [
+    CORS_ALLOWED_ORIGIN_REGEXES = [
         r"^https://\w+\.example\.com$",
     ]
+
+Previously this setting was called ``CORS_ORIGIN_REGEX_WHITELIST``, which still
+works as an alias, with the new name takeing precedence.
+
+``CORS_ORIGIN_ALLOW_ALL``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+If ``True``, all origins will be allowed. Other settings restricting allowed
+origins will be ignored. Defaults to ``False``.
+
+Setting this to ``True`` can be *dangerous*, as it allows any website to make
+cross-origin requests to yours. Generally you'll want to restrict the list of
+allowed origins with ``CORS_ALLOWED_ORIGINS`` or
+``CORS_ALLOWED_ORIGIN_REGEXES``.
 
 --------------
 
@@ -286,7 +298,7 @@ For example:
 
 .. code-block:: python
 
-    CORS_ORIGIN_ALLOWLIST = [
+    CORS_ALLOWED_ORIGINS = [
         'http://read.only.com',
         'http://change.allowed.com',
     ]
@@ -377,7 +389,7 @@ of URL's, whilst allowing a normal set of origins to access *all* URL's. This
 isn't possible using just the normal configuration, but it can be achieved with
 a signal handler.
 
-First set ``CORS_ORIGIN_ALLOWLIST`` to the list of trusted origins that are
+First set ``CORS_ALLOWED_ORIGINS`` to the list of trusted origins that are
 allowed to access every URL, and then add a handler to
 ``check_request_enabled`` to allow CORS regardless of the origin for the
 unrestricted URL's. For example:

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -90,7 +90,10 @@ def check_settings(app_configs, **kwargs):
                             repr(origin), allowed_origins_alias
                         ),
                         id="corsheaders.E013",
-                        hint="Add a scheme (e.g. https://) or netloc (e.g. example.com).",
+                        hint=(
+                            "Add a scheme (e.g. https://) or netloc (e.g. "
+                            + "example.com)."
+                        ),
                     )
                 )
             else:

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -59,10 +59,15 @@ def check_settings(app_configs, **kwargs):
             )
         )
 
-    if not is_sequence(conf.CORS_ORIGIN_ALLOWLIST, str):
+    if hasattr(settings, "CORS_ALLOWED_ORIGINS"):
+        allowed_origins_alias = "CORS_ALLOWED_ORIGINS"
+    else:
+        allowed_origins_alias = "CORS_ORIGIN_WHITELIST"
+
+    if not is_sequence(conf.CORS_ALLOWED_ORIGINS, str):
         errors.append(
             checks.Error(
-                "CORS_ORIGIN_ALLOWLIST should be a sequence of strings.",
+                "{} should be a sequence of strings.".format(allowed_origins_alias),
                 id="corsheaders.E006",
             )
         )
@@ -74,22 +79,18 @@ def check_settings(app_configs, **kwargs):
             # https://bugs.chromium.org/p/chromium/issues/detail?id=991107
             "file://",
         )
-        for origin in conf.CORS_ORIGIN_ALLOWLIST:
+        for origin in conf.CORS_ALLOWED_ORIGINS:
             if origin in special_origin_values:
                 continue
             parsed = urlparse(origin)
             if parsed.scheme == "" or parsed.netloc == "":
                 errors.append(
                     checks.Error(
-                        (
-                            "Origin {} in CORS_ORIGIN_ALLOWLIST is missing "
-                            + " scheme or netloc"
-                        ).format(repr(origin)),
-                        id="corsheaders.E013",
-                        hint=(
-                            "Add a scheme (e.g. https://) or netloc (e.g. "
-                            + "example.com)."
+                        "Origin {} in {} is missing scheme or netloc".format(
+                            repr(origin), allowed_origins_alias
                         ),
+                        id="corsheaders.E013",
+                        hint="Add a scheme (e.g. https://) or netloc (e.g. example.com).",
                     )
                 )
             else:
@@ -99,20 +100,22 @@ def check_settings(app_configs, **kwargs):
                     if getattr(parsed, part) != "":
                         errors.append(
                             checks.Error(
-                                (
-                                    "Origin {} in CORS_ORIGIN_ALLOWLIST should "
-                                    + "not have {}"
-                                ).format(repr(origin), part),
+                                "Origin {} in {} should not have {}".format(
+                                    repr(origin), allowed_origins_alias, part
+                                ),
                                 id="corsheaders.E014",
                             )
                         )
 
-    if not is_sequence(conf.CORS_ORIGIN_REGEX_ALLOWLIST, (str, re_type)):
+    if hasattr(settings, "CORS_ALLOWED_ORIGIN_REGEXES"):
+        allowed_regexes_alias = "CORS_ALLOWED_ORIGIN_REGEXES"
+    else:
+        allowed_regexes_alias = "CORS_ORIGIN_REGEX_WHITELIST"
+    if not is_sequence(conf.CORS_ALLOWED_ORIGIN_REGEXES, (str, re_type)):
         errors.append(
             checks.Error(
-                (
-                    "CORS_ORIGIN_REGEX_ALLOWLIST should be a sequence of "
-                    + "strings and/or compiled regexes."
+                "{} should be a sequence of strings and/or compiled regexes.".format(
+                    allowed_regexes_alias
                 ),
                 id="corsheaders.E007",
             )

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -59,10 +59,10 @@ def check_settings(app_configs, **kwargs):
             )
         )
 
-    if not is_sequence(conf.CORS_ORIGIN_WHITELIST, str):
+    if not is_sequence(conf.CORS_ORIGIN_ALLOWLIST, str):
         errors.append(
             checks.Error(
-                "CORS_ORIGIN_WHITELIST should be a sequence of strings.",
+                "CORS_ORIGIN_ALLOWLIST should be a sequence of strings.",
                 id="corsheaders.E006",
             )
         )
@@ -74,7 +74,7 @@ def check_settings(app_configs, **kwargs):
             # https://bugs.chromium.org/p/chromium/issues/detail?id=991107
             "file://",
         )
-        for origin in conf.CORS_ORIGIN_WHITELIST:
+        for origin in conf.CORS_ORIGIN_ALLOWLIST:
             if origin in special_origin_values:
                 continue
             parsed = urlparse(origin)
@@ -82,7 +82,7 @@ def check_settings(app_configs, **kwargs):
                 errors.append(
                     checks.Error(
                         (
-                            "Origin {} in CORS_ORIGIN_WHITELIST is missing "
+                            "Origin {} in CORS_ORIGIN_ALLOWLIST is missing "
                             + " scheme or netloc"
                         ).format(repr(origin)),
                         id="corsheaders.E013",
@@ -100,18 +100,18 @@ def check_settings(app_configs, **kwargs):
                         errors.append(
                             checks.Error(
                                 (
-                                    "Origin {} in CORS_ORIGIN_WHITELIST should "
+                                    "Origin {} in CORS_ORIGIN_ALLOWLIST should "
                                     + "not have {}"
                                 ).format(repr(origin), part),
                                 id="corsheaders.E014",
                             )
                         )
 
-    if not is_sequence(conf.CORS_ORIGIN_REGEX_WHITELIST, (str, re_type)):
+    if not is_sequence(conf.CORS_ORIGIN_REGEX_ALLOWLIST, (str, re_type)):
         errors.append(
             checks.Error(
                 (
-                    "CORS_ORIGIN_REGEX_WHITELIST should be a sequence of "
+                    "CORS_ORIGIN_REGEX_ALLOWLIST should be a sequence of "
                     + "strings and/or compiled regexes."
                 ),
                 id="corsheaders.E007",

--- a/src/corsheaders/conf.py
+++ b/src/corsheaders/conf.py
@@ -30,20 +30,20 @@ class Settings:
         return getattr(settings, "CORS_ORIGIN_ALLOW_ALL", False)
 
     @property
-    def CORS_ORIGIN_ALLOWLIST(self):
-        allowlist = getattr(settings, "CORS_ORIGIN_ALLOWLIST", None)
-        if allowlist is not None:
-            return allowlist
-
-        return getattr(settings, "CORS_ORIGIN_WHITELIST", ())
+    def CORS_ALLOWED_ORIGINS(self):
+        return getattr(
+            settings,
+            "CORS_ALLOWED_ORIGINS",
+            getattr(settings, "CORS_ORIGIN_WHITELIST", ()),
+        )
 
     @property
-    def CORS_ORIGIN_REGEX_ALLOWLIST(self):
-        regex_allowlist = getattr(settings, "CORS_ORIGIN_REGEX_ALLOWLIST", None)
-        if regex_allowlist is not None:
-            return regex_allowlist
-
-        return getattr(settings, "CORS_ORIGIN_REGEX_WHITELIST", ())
+    def CORS_ALLOWED_ORIGIN_REGEXES(self):
+        return getattr(
+            settings,
+            "CORS_ALLOWED_ORIGIN_REGEXES",
+            getattr(settings, "CORS_ORIGIN_REGEX_WHITELIST", ()),
+        )
 
     @property
     def CORS_EXPOSE_HEADERS(self):

--- a/src/corsheaders/conf.py
+++ b/src/corsheaders/conf.py
@@ -30,11 +30,19 @@ class Settings:
         return getattr(settings, "CORS_ORIGIN_ALLOW_ALL", False)
 
     @property
-    def CORS_ORIGIN_WHITELIST(self):
+    def CORS_ORIGIN_ALLOWLIST(self):
+        allowlist = getattr(settings, "CORS_ORIGIN_ALLOWLIST", None)
+        if allowlist is not None:
+            return allowlist
+
         return getattr(settings, "CORS_ORIGIN_WHITELIST", ())
 
     @property
-    def CORS_ORIGIN_REGEX_WHITELIST(self):
+    def CORS_ORIGIN_REGEX_ALLOWLIST(self):
+        regex_allowlist = getattr(settings, "CORS_ORIGIN_REGEX_ALLOWLIST", None)
+        if regex_allowlist is not None:
+            return regex_allowlist
+
         return getattr(settings, "CORS_ORIGIN_REGEX_WHITELIST", ())
 
     @property

--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -147,13 +147,13 @@ class CorsMiddleware(MiddlewareMixin):
 
     def origin_found_in_white_lists(self, origin, url):
         return (
-            (origin == "null" and origin in conf.CORS_ORIGIN_WHITELIST)
+            (origin == "null" and origin in conf.CORS_ORIGIN_ALLOWLIST)
             or self._url_in_whitelist(url)
             or self.regex_domain_match(origin)
         )
 
     def regex_domain_match(self, origin):
-        for domain_pattern in conf.CORS_ORIGIN_REGEX_WHITELIST:
+        for domain_pattern in conf.CORS_ORIGIN_REGEX_ALLOWLIST:
             if re.match(domain_pattern, origin):
                 return origin
 
@@ -167,7 +167,7 @@ class CorsMiddleware(MiddlewareMixin):
         return any(return_value for function, return_value in signal_responses)
 
     def _url_in_whitelist(self, url):
-        origins = [urlparse(o) for o in conf.CORS_ORIGIN_WHITELIST]
+        origins = [urlparse(o) for o in conf.CORS_ORIGIN_ALLOWLIST]
         return any(
             origin.scheme == url.scheme and origin.netloc == url.netloc
             for origin in origins

--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -147,13 +147,13 @@ class CorsMiddleware(MiddlewareMixin):
 
     def origin_found_in_white_lists(self, origin, url):
         return (
-            (origin == "null" and origin in conf.CORS_ORIGIN_ALLOWLIST)
+            (origin == "null" and origin in conf.CORS_ALLOWED_ORIGINS)
             or self._url_in_whitelist(url)
             or self.regex_domain_match(origin)
         )
 
     def regex_domain_match(self, origin):
-        for domain_pattern in conf.CORS_ORIGIN_REGEX_ALLOWLIST:
+        for domain_pattern in conf.CORS_ALLOWED_ORIGIN_REGEXES:
             if re.match(domain_pattern, origin):
                 return origin
 
@@ -167,7 +167,7 @@ class CorsMiddleware(MiddlewareMixin):
         return any(return_value for function, return_value in signal_responses)
 
     def _url_in_whitelist(self, url):
-        origins = [urlparse(o) for o in conf.CORS_ORIGIN_ALLOWLIST]
+        origins = [urlparse(o) for o in conf.CORS_ALLOWED_ORIGINS]
         return any(
             origin.scheme == url.scheme and origin.netloc == url.netloc
             for origin in origins

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -59,36 +59,36 @@ class ChecksTests(SimpleTestCase):
     def test_cors_origin_allow_all_non_bool(self):
         self.check_error_codes(["corsheaders.E005"])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=object)
-    def test_cors_origin_whitelist_non_sequence(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=object)
+    def test_cors_origin_allowlist_non_sequence(self):
         self.check_error_codes(["corsheaders.E006"])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=[object])
-    def test_cors_origin_whitelist_non_string(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=[object])
+    def test_cors_origin_allowlist_non_string(self):
         self.check_error_codes(["corsheaders.E006"])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com", "file://", "null"])
-    def test_cors_origin_whitelist_allowed(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com", "file://", "null"])
+    def test_cors_origin_allowlist_allowed(self):
         self.check_error_codes([])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["example.com"])
-    def test_cors_origin_whitelist_no_scheme(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["example.com"])
+    def test_cors_origin_allowlist_no_scheme(self):
         self.check_error_codes(["corsheaders.E013"])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["https://"])
-    def test_cors_origin_whitelist_no_netloc(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["https://"])
+    def test_cors_origin_allowlist_no_netloc(self):
         self.check_error_codes(["corsheaders.E013"])
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["https://example.com/foobar"])
-    def test_cors_origin_whitelist_path(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["https://example.com/foobar"])
+    def test_cors_origin_allowlist_path(self):
         self.check_error_codes(["corsheaders.E014"])
 
-    @override_settings(CORS_ORIGIN_REGEX_WHITELIST=object)
-    def test_cors_origin_regex_whitelist_non_sequence(self):
+    @override_settings(CORS_ORIGIN_REGEX_ALLOWLIST=object)
+    def test_cors_origin_regex_allowlist_non_sequence(self):
         self.check_error_codes(["corsheaders.E007"])
 
-    @override_settings(CORS_ORIGIN_REGEX_WHITELIST=[re.compile(r"a")])
-    def test_cors_origin_regex_whitelist_regex(self):
+    @override_settings(CORS_ORIGIN_REGEX_ALLOWLIST=[re.compile(r"a")])
+    def test_cors_origin_regex_allowlist_regex(self):
         self.check_error_codes([])
 
     @override_settings(CORS_EXPOSE_HEADERS=object)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -9,16 +9,22 @@ class ConfTests(SimpleTestCase):
     def test_can_override(self):
         assert conf.CORS_ALLOW_HEADERS == ["foo"]
 
+    @override_settings(CORS_ORIGIN_WHITELIST=["example.com"])
+    def test_cors_allowed_origins_old_alias(self):
+        assert conf.CORS_ALLOWED_ORIGINS == ["example.com"]
+
     @override_settings(
-        CORS_ORIGIN_WHITELIST=["whitelist"], CORS_ORIGIN_ALLOWLIST=["allowlist"]
+        CORS_ALLOWED_ORIGINS=["example.com"], CORS_ORIGIN_WHITELIST=["example.org"]
     )
-    def test_allowlist_whitelist_priority(self):
-        assert conf.CORS_ORIGIN_ALLOWLIST == ["allowlist"]
+    def test_cors_allowed_origins_new_setting_takes_precedence(self):
+        assert conf.CORS_ALLOWED_ORIGINS == ["example.com"]
 
-    @override_settings(CORS_ORIGIN_ALLOWLIST=["allowlist"])
-    def test_allowlist_only(self):
-        assert conf.CORS_ORIGIN_ALLOWLIST == ["allowlist"]
+    @override_settings(CORS_ORIGIN_REGEX_WHITELIST=[r".*"])
+    def test_cors_allowed_origin_regexes_old_alias(self):
+        assert conf.CORS_ALLOWED_ORIGIN_REGEXES == [".*"]
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["whitelist"])
-    def test_whitelist_only(self):
-        assert conf.CORS_ORIGIN_ALLOWLIST == ["whitelist"]
+    @override_settings(
+        CORS_ALLOWED_ORIGIN_REGEXES=["a+"], CORS_ORIGIN_REGEX_WHITELIST=[".*"]
+    )
+    def test_cors_allowed_origin_regexes_new_setting_takes_precedence(self):
+        assert conf.CORS_ALLOWED_ORIGIN_REGEXES == ["a+"]

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -8,3 +8,17 @@ class ConfTests(SimpleTestCase):
     @override_settings(CORS_ALLOW_HEADERS=["foo"])
     def test_can_override(self):
         assert conf.CORS_ALLOW_HEADERS == ["foo"]
+
+    @override_settings(
+        CORS_ORIGIN_WHITELIST=["whitelist"], CORS_ORIGIN_ALLOWLIST=["allowlist"]
+    )
+    def test_allowlist_whitelist_priority(self):
+        assert conf.CORS_ORIGIN_ALLOWLIST == ["allowlist"]
+
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["allowlist"])
+    def test_allowlist_only(self):
+        assert conf.CORS_ORIGIN_ALLOWLIST == ["allowlist"]
+
+    @override_settings(CORS_ORIGIN_WHITELIST=["whitelist"])
+    def test_whitelist_only(self):
+        assert conf.CORS_ORIGIN_ALLOWLIST == ["whitelist"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -32,30 +32,30 @@ class CorsMiddlewareTests(TestCase):
         resp = self.client.get("/")
         assert resp["Vary"] == "Origin"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
-    def test_get_not_in_whitelist(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com"])
+    def test_get_not_in_allowlist(self):
         resp = self.client.get("/", HTTP_ORIGIN="http://example.org")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["https://example.org"])
-    def test_get_not_in_whitelist_due_to_wrong_scheme(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["https://example.org"])
+    def test_get_not_in_allowlist_due_to_wrong_scheme(self):
         resp = self.client.get("/", HTTP_ORIGIN="http://example.org")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=["http://example.com", "http://example.org"]
+        CORS_ORIGIN_ALLOWLIST=["http://example.com", "http://example.org"]
     )
-    def test_get_in_whitelist(self):
+    def test_get_in_allowlist(self):
         resp = self.client.get("/", HTTP_ORIGIN="http://example.org")
         assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.org"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com", "null"])
-    def test_null_in_whitelist(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com", "null"])
+    def test_null_in_allowlist(self):
         resp = self.client.get("/", HTTP_ORIGIN="null")
         assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "null"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com", "file://"])
-    def test_file_in_whitelist(self):
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com", "file://"])
+    def test_file_in_allowlist(self):
         """
         'file://' should be allowed as an origin since Chrome on Android
         mistakenly sends it
@@ -113,27 +113,27 @@ class CorsMiddlewareTests(TestCase):
     @override_settings(
         CORS_ALLOW_METHODS=["OPTIONS"],
         CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_WHITELIST=["http://localhost:9000"],
+        CORS_ORIGIN_ALLOWLIST=["http://localhost:9000"],
     )
-    def test_options_whitelist_with_port(self):
+    def test_options_allowlist_with_port(self):
         resp = self.client.options("/", HTTP_ORIGIN="http://localhost:9000")
         assert resp[ACCESS_CONTROL_ALLOW_CREDENTIALS] == "true"
 
     @override_settings(
         CORS_ALLOW_METHODS=["OPTIONS"],
         CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_REGEX_WHITELIST=[r"^http?://(\w+\.)?example\.com$"],
+        CORS_ORIGIN_REGEX_ALLOWLIST=[r"^http?://(\w+\.)?example\.com$"],
     )
-    def test_options_adds_origin_when_domain_found_in_origin_regex_whitelist(self):
+    def test_options_adds_origin_when_domain_found_in_origin_regex_allowlist(self):
         resp = self.client.options("/", HTTP_ORIGIN="http://foo.example.com")
         assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://foo.example.com"
 
     @override_settings(
         CORS_ALLOW_METHODS=["OPTIONS"],
         CORS_ALLOW_CREDENTIALS=True,
-        CORS_ORIGIN_REGEX_WHITELIST=(r"^http?://(\w+\.)?example\.org$",),
+        CORS_ORIGIN_REGEX_ALLOWLIST=(r"^http?://(\w+\.)?example\.org$",),
     )
-    def test_options_will_not_add_origin_when_domain_not_found_in_origin_regex_whitelist(  # noqa: B950
+    def test_options_will_not_add_origin_when_domain_not_found_in_origin_regex_allowlist(  # noqa: B950
         self,
     ):
         resp = self.client.options("/", HTTP_ORIGIN="http://foo.example.com")
@@ -225,7 +225,7 @@ class CorsMiddlewareTests(TestCase):
             assert resp.status_code == 200
             assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.com"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com"])
     def test_signal_handler_allow_some_urls_to_everyone(self):
         def allow_api_to_all(sender, request, **kwargs):
             return request.path.startswith("/api/")
@@ -247,7 +247,7 @@ class CorsMiddlewareTests(TestCase):
             assert resp.status_code == 200
             assert resp[ACCESS_CONTROL_ALLOW_ORIGIN] == "http://example.org"
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com"])
     def test_signal_called_once_during_normal_flow(self):
         def allow_all(sender, request, **kwargs):
             allow_all.calls += 1
@@ -260,7 +260,7 @@ class CorsMiddlewareTests(TestCase):
 
             assert allow_all.calls == 1
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com"])
     @prepend_middleware("tests.test_middleware.ShortCircuitMiddleware")
     def test_get_short_circuit(self):
         """
@@ -273,7 +273,7 @@ class CorsMiddlewareTests(TestCase):
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
+        CORS_ORIGIN_ALLOWLIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
     )
     @prepend_middleware(__name__ + ".ShortCircuitMiddleware")
     def test_get_short_circuit_should_be_ignored(self):
@@ -281,21 +281,21 @@ class CorsMiddlewareTests(TestCase):
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
+        CORS_ORIGIN_ALLOWLIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
     )
     def test_get_regex_matches(self):
         resp = self.client.get("/foo/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=["http://example.com"], CORS_URLS_REGEX=r"^/not-foo/$"
+        CORS_ORIGIN_ALLOWLIST=["http://example.com"], CORS_URLS_REGEX=r"^/not-foo/$"
     )
     def test_get_regex_doesnt_match(self):
         resp = self.client.get("/foo/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 
     @override_settings(
-        CORS_ORIGIN_WHITELIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
+        CORS_ORIGIN_ALLOWLIST=["http://example.com"], CORS_URLS_REGEX=r"^/foo/$"
     )
     def test_get_regex_matches_path_info(self):
         resp = self.client.get(
@@ -303,7 +303,7 @@ class CorsMiddlewareTests(TestCase):
         )
         assert ACCESS_CONTROL_ALLOW_ORIGIN in resp
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com"])
     def test_cors_enabled_is_attached_and_bool(self):
         """
         Ensure that request._cors_enabled is available - although a private API
@@ -314,7 +314,7 @@ class CorsMiddlewareTests(TestCase):
         assert isinstance(request._cors_enabled, bool)
         assert request._cors_enabled
 
-    @override_settings(CORS_ORIGIN_WHITELIST=["http://example.com"])
+    @override_settings(CORS_ORIGIN_ALLOWLIST=["http://example.com"])
     def test_works_if_view_deletes_cors_enabled(self):
         """
         Just in case something crazy happens in the view or other middleware,
@@ -325,7 +325,7 @@ class CorsMiddlewareTests(TestCase):
 
 
 @override_settings(
-    CORS_REPLACE_HTTPS_REFERER=True, CORS_ORIGIN_REGEX_WHITELIST=(r".*example.*",)
+    CORS_REPLACE_HTTPS_REFERER=True, CORS_ORIGIN_REGEX_ALLOWLIST=(r".*example.*",)
 )
 class RefererReplacementCorsMiddlewareTests(TestCase):
     def test_get_replaces_referer_when_secure(self):
@@ -401,7 +401,7 @@ class RefererReplacementCorsMiddlewareTests(TestCase):
         assert resp.wsgi_request.META["HTTP_REFERER"] == "https://example.org/foo"
         assert "ORIGINAL_HTTP_REFERER" not in resp.wsgi_request.META
 
-    @override_settings(CORS_ORIGIN_REGEX_WHITELIST=())
+    @override_settings(CORS_ORIGIN_REGEX_ALLOWLIST=())
     def test_get_does_not_replace_referer_when_not_valid_request(self):
         resp = self.client.get(
             "/",

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -133,9 +133,7 @@ class CorsMiddlewareTests(TestCase):
         CORS_ALLOW_CREDENTIALS=True,
         CORS_ALLOWED_ORIGIN_REGEXES=[r"^http?://(\w+\.)?example\.org$"],
     )
-    def test_options_doesnt_add_origin_when_domain_not_found_in_allowed_regexes(
-        self,
-    ):
+    def test_options_doesnt_add_origin_when_domain_not_found_in_allowed_regexes(self,):
         resp = self.client.options("/", HTTP_ORIGIN="http://foo.example.com")
         assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp
 


### PR DESCRIPTION
Recreation of #531 with my edits.

Following Django’s example in [Ticket #31670](https://code.djangoproject.com/ticket/31670), rename these settings:

* `CORS_ORIGIN_WHITELIST`   -> `CORS_ALLOWED_ORIGINS`
* `CORS_ORIGIN_WHITELIST_REGEX` -> `CORS_ALLOWED_ORIGIN_REGEXES`

The old names are preserved as aliases for backward compatibility.