### PR TITLE
Mention Django 3.1 support in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Requirements
 
 Python 3.5 to 3.8 supported.
 
-Django 2.2 to 3.0 supported.
+Django 2.2 to 3.1 supported.
 
 ----
 


### PR DESCRIPTION
Django 3.1 is supported and tested since version 3.4.0.