### PR TITLE
Fixed formatting issue in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,10 +79,10 @@ You will also need to add a middleware class to listen in on responses:
 .. code-block:: python
 
     MIDDLEWARE = [
-        ...
+        ...,
         'corsheaders.middleware.CorsMiddleware',
         'django.middleware.common.CommonMiddleware',
-        ...
+        ...,
     ]
 
 ``CorsMiddleware`` should be placed as high as possible, especially before any


### PR DESCRIPTION
The lack of a `,` behind the ellipsis caused the GitHub rst renderer to not properly render the string containing the middleware as a string but as a Python path + class.

![image](https://user-images.githubusercontent.com/475613/109009785-3fff9180-76af-11eb-8300-0533e07fa209.png)
![image](https://user-images.githubusercontent.com/475613/109009841-560d5200-76af-11eb-9783-e44dd4c5d9e1.png)
