### PR TITLE
Improve Flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,5 @@ source =
 show_missing = True
 
 [flake8]
-max-line-length = 80
-select = E,F,W,B,B950,C,I,TYP
-ignore = E203,E501,W503
+max-line-length = 88
+extend-ignore = E203

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -185,7 +185,7 @@ class CorsMiddlewareTests(TestCase):
         django-cors-middleware, so at least this test makes that explicit, especially
         since for the switch to Django 1.10, special-handling will need to be put in
         place to preserve this behaviour. See `ExceptionMiddleware` mention here:
-        https://docs.djangoproject.com/en/3.0/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware  # noqa: B950
+        https://docs.djangoproject.com/en/3.0/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware  # noqa: E501
         """
         resp = self.client.get("/test-401/", HTTP_ORIGIN="http://example.com")
         assert resp.status_code == 401


### PR DESCRIPTION
Use only Black compat options. Removing 'select' declaration means that plugin error codes are selected by default.
