### PR TITLE
Update documented CSRF_TRUSTED_ORIGINS for Django 4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,7 +318,7 @@ For example:
     ]
 
     CSRF_TRUSTED_ORIGINS = [
-        "change.allowed.com",
+        "http://change.allowed.com",
     ]
 
 ``CORS_REPLACE_HTTPS_REFERER: bool``


### PR DESCRIPTION
url scheme is mandatory in Django 4 for CSRF_TRUSTED_ORIGINS