### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - src:tests
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     args:
     - --py37-plus
     - --application-directories
-    - src:tests
+    - .:src
     - --add-import
     - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     args:
     - --py37-plus
     - --application-directories
-    - .:src
+    - .:example:src
     - --add-import
     - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/corsheaders/apps.py
+++ b/src/corsheaders/apps.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django.apps import AppConfig
-from django.core.checks import Tags, register
+from django.core.checks import register
+from django.core.checks import Tags
 
 from corsheaders.checks import check_settings
 

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -7,7 +7,8 @@ from urllib.parse import urlsplit
 
 from django.apps import AppConfig
 from django.conf import settings
-from django.core.checks import CheckMessage, Error
+from django.core.checks import CheckMessage
+from django.core.checks import Error
 
 from corsheaders.conf import conf
 

--- a/src/corsheaders/conf.py
+++ b/src/corsheaders/conf.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
-from typing import List, Pattern, Sequence, Tuple, Union, cast
+from typing import cast
+from typing import List
+from typing import Pattern
+from typing import Sequence
+from typing import Tuple
+from typing import Union
 
 from django.conf import settings
 
+from corsheaders.defaults import default_headers
+from corsheaders.defaults import default_methods
+
 # Kept here for backwards compatibility
-from corsheaders.defaults import default_headers, default_methods
 
 
 class Settings:

--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import re
 from typing import Any
-from urllib.parse import SplitResult, urlsplit
+from urllib.parse import SplitResult
+from urllib.parse import urlsplit
 
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
+from django.http import HttpResponse
 from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import re
 
 import pytest
-from django.core.checks import CheckMessage, Error
-from django.core.management import base, call_command
+from django.core.checks import CheckMessage
+from django.core.checks import Error
+from django.core.management import base
+from django.core.management import call_command
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -4,20 +4,16 @@ from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.deprecation import MiddlewareMixin
+from tests.utils import append_middleware
+from tests.utils import prepend_middleware
+from tests.utils import temporary_check_request_hander
 
-from corsheaders.middleware import (
-    ACCESS_CONTROL_ALLOW_CREDENTIALS,
-    ACCESS_CONTROL_ALLOW_HEADERS,
-    ACCESS_CONTROL_ALLOW_METHODS,
-    ACCESS_CONTROL_ALLOW_ORIGIN,
-    ACCESS_CONTROL_EXPOSE_HEADERS,
-    ACCESS_CONTROL_MAX_AGE,
-)
-from tests.utils import (
-    append_middleware,
-    prepend_middleware,
-    temporary_check_request_hander,
-)
+from corsheaders.middleware import ACCESS_CONTROL_ALLOW_CREDENTIALS
+from corsheaders.middleware import ACCESS_CONTROL_ALLOW_HEADERS
+from corsheaders.middleware import ACCESS_CONTROL_ALLOW_METHODS
+from corsheaders.middleware import ACCESS_CONTROL_ALLOW_ORIGIN
+from corsheaders.middleware import ACCESS_CONTROL_EXPOSE_HEADERS
+from corsheaders.middleware import ACCESS_CONTROL_MAX_AGE
 
 
 class ShortCircuitMiddleware(MiddlewareMixin):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -4,9 +4,6 @@ from django.http import HttpResponse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.deprecation import MiddlewareMixin
-from tests.utils import append_middleware
-from tests.utils import prepend_middleware
-from tests.utils import temporary_check_request_hander
 
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_CREDENTIALS
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_HEADERS
@@ -14,6 +11,9 @@ from corsheaders.middleware import ACCESS_CONTROL_ALLOW_METHODS
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_ORIGIN
 from corsheaders.middleware import ACCESS_CONTROL_EXPOSE_HEADERS
 from corsheaders.middleware import ACCESS_CONTROL_MAX_AGE
+from tests.utils import append_middleware
+from tests.utils import prepend_middleware
+from tests.utils import temporary_check_request_hander
 
 
 class ShortCircuitMiddleware(MiddlewareMixin):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.http import Http404, HttpResponse
+from django.http import Http404
+from django.http import HttpResponse
 from django.urls import path
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Callable, Generator
+from typing import Callable
+from typing import Generator
 
 from django.test.utils import modify_settings
 


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
