### PR TITLE
Added default_auto_field variable to CorsHeader AppConfig

### DIFF
--- a/src/corsheaders/apps.py
+++ b/src/corsheaders/apps.py
@@ -10,6 +10,7 @@ from corsheaders.checks import check_settings
 class CorsHeadersAppConfig(AppConfig):
     name = "corsheaders"
     verbose_name = "django-cors-headers"
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self) -> None:
         register(Tags.security)(check_settings)

--- a/src/corsheaders/apps.py
+++ b/src/corsheaders/apps.py
@@ -10,7 +10,7 @@ from corsheaders.checks import check_settings
 class CorsHeadersAppConfig(AppConfig):
     name = "corsheaders"
     verbose_name = "django-cors-headers"
-    default_auto_field = 'django.db.models.AutoField'
+    default_auto_field = "django.db.models.AutoField"
 
     def ready(self) -> None:
         register(Tags.security)(check_settings)


### PR DESCRIPTION
Added `default_auto_field` property to CorsHeaderAppConfig.

Test Environment: 
- Python 3.10.3
- Django 4.1.5

I've experience an issue where if django's `DEFAULT_AUTO_FIELD` is set within django `settings.py` to use any values other than the default `AutoField`. This will caused django to try to generate a new migration within the library which is not an intended behavior.

Erroneous Log (python manage.py makemigrations):
```
Migrations for 'corsheaders':
  <PYTHON_SITE_PACKAGES_DIR>/corsheaders/migrations/0002_alter_corsmodel_id.py
    - Alter field id on corsmodel
```