### PR TITLE
Add Local Network Access support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Changelog
 
 * Add async support to the middleware, reducing overhead on async views.
 
+* Added support for `private network access <https://wicg.github.io/local-network-access/>`_.
+
 3.14.0 (2023-02-25)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changelog
 
 * Add async support to the middleware, reducing overhead on async views.
 
-* Added support for `private network access <https://wicg.github.io/local-network-access/>`_.
+* Add ``CORS_ALLOW_PRIVATE_NETWORK_ACCESS`` setting, which enables support for the Local Network Access draft specification.
 
 3.14.0 (2023-02-25)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -300,8 +300,8 @@ Change the setting to ``'None'`` if you need to bypass this security restriction
 
 .. _SESSION_COOKIE_SAMESITE: https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE
 
-``CORS_ALLOW_PRIVATE_NETWORK_ACCESS: bool``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``CORS_ALLOW_PRIVATE_NETWORK: bool``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If ``True``, allow requests from sites on “public” IP to this server on a “private” IP.
 In such cases, browsers send an extra CORS header ``access-control-request-private-network``, for which ``OPTIONS`` responses must contain ``access-control-allow-private-network: true``.

--- a/README.rst
+++ b/README.rst
@@ -300,6 +300,18 @@ Change the setting to ``'None'`` if you need to bypass this security restriction
 
 .. _SESSION_COOKIE_SAMESITE: https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE
 
+``CORS_ALLOW_PRIVATE_NETWORK_ACCESS: bool``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It set to ``True``, browsers running in CORS mode and enforcing private network access will be
+still be allowed to access this Django instance if it is running on an IP from the private IP
+address space while the CORS origin's server is running on an IP from the public IP address space.
+
+For further information, see the
+`W3C Community Draft <https://wicg.github.io/local-network-access/>`__ or the
+`Google Chrome Blog post <https://developer.chrome.com/blog/private-network-access-preflight/>`__
+announcing the feature.
+
 CSRF Integration
 ----------------
 

--- a/README.rst
+++ b/README.rst
@@ -301,16 +301,15 @@ Change the setting to ``'None'`` if you need to bypass this security restriction
 .. _SESSION_COOKIE_SAMESITE: https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE
 
 ``CORS_ALLOW_PRIVATE_NETWORK_ACCESS: bool``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It set to ``True``, browsers running in CORS mode and enforcing private network access will be
-still be allowed to access this Django instance if it is running on an IP from the private IP
-address space while the CORS origin's server is running on an IP from the public IP address space.
+If ``True``, allow requests from sites on “public” IP to this server on a “private” IP.
+In such cases, browsers send an extra CORS header ``access-control-request-private-network``, for which ``OPTIONS`` responses must contain ``access-control-allow-private-network: true``.
 
-For further information, see the
-`W3C Community Draft <https://wicg.github.io/local-network-access/>`__ or the
-`Google Chrome Blog post <https://developer.chrome.com/blog/private-network-access-preflight/>`__
-announcing the feature.
+Refer to:
+
+* `Local Network Access <https://wicg.github.io/local-network-access/>`__, the W3C Community Draft specification.
+* `Private Network Access: introducing preflights <https://developer.chrome.com/blog/private-network-access-preflight/>`__, a blog post from the Google Chrome team.
 
 CSRF Integration
 ----------------

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -38,6 +38,11 @@ def check_settings(**kwargs: Any) -> list[CheckMessage]:
             Error("CORS_ALLOW_CREDENTIALS should be a bool.", id="corsheaders.E003")
         )
 
+    if not isinstance(conf.CORS_ALLOW_PRIVATE_NETWORK_ACCESS, bool):
+        errors.append(
+            Error("CORS_ALLOW_PRIVATE_NETWORK_ACCESS should be a bool.", id="corsheaders.E015")
+        )
+
     if (
         not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, int)
         or conf.CORS_PREFLIGHT_MAX_AGE < 0

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -38,10 +38,10 @@ def check_settings(**kwargs: Any) -> list[CheckMessage]:
             Error("CORS_ALLOW_CREDENTIALS should be a bool.", id="corsheaders.E003")
         )
 
-    if not isinstance(conf.CORS_ALLOW_PRIVATE_NETWORK_ACCESS, bool):
+    if not isinstance(conf.CORS_ALLOW_PRIVATE_NETWORK, bool):
         errors.append(  # type: ignore [unreachable]
             Error(
-                "CORS_ALLOW_PRIVATE_NETWORK_ACCESS should be a bool.",
+                "CORS_ALLOW_PRIVATE_NETWORK should be a bool.",
                 id="corsheaders.E015",
             )
         )

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -39,7 +39,7 @@ def check_settings(**kwargs: Any) -> list[CheckMessage]:
         )
 
     if not isinstance(conf.CORS_ALLOW_PRIVATE_NETWORK_ACCESS, bool):
-        errors.append(
+        errors.append(  # type: ignore [unreachable]
             Error(
                 "CORS_ALLOW_PRIVATE_NETWORK_ACCESS should be a bool.",
                 id="corsheaders.E015",

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -40,7 +40,10 @@ def check_settings(**kwargs: Any) -> list[CheckMessage]:
 
     if not isinstance(conf.CORS_ALLOW_PRIVATE_NETWORK_ACCESS, bool):
         errors.append(
-            Error("CORS_ALLOW_PRIVATE_NETWORK_ACCESS should be a bool.", id="corsheaders.E015")
+            Error(
+                "CORS_ALLOW_PRIVATE_NETWORK_ACCESS should be a bool.",
+                id="corsheaders.E015",
+            )
         )
 
     if (

--- a/src/corsheaders/conf.py
+++ b/src/corsheaders/conf.py
@@ -33,6 +33,10 @@ class Settings:
         return getattr(settings, "CORS_ALLOW_CREDENTIALS", False)
 
     @property
+    def CORS_ALLOW_PRIVATE_NETWORK_ACCESS(self) -> bool:
+        return getattr(settings, "CORS_ALLOW_PRIVATE_NETWORK_ACCESS", False)
+
+    @property
     def CORS_PREFLIGHT_MAX_AGE(self) -> int:
         return getattr(settings, "CORS_PREFLIGHT_MAX_AGE", 86400)
 

--- a/src/corsheaders/conf.py
+++ b/src/corsheaders/conf.py
@@ -33,8 +33,8 @@ class Settings:
         return getattr(settings, "CORS_ALLOW_CREDENTIALS", False)
 
     @property
-    def CORS_ALLOW_PRIVATE_NETWORK_ACCESS(self) -> bool:
-        return getattr(settings, "CORS_ALLOW_PRIVATE_NETWORK_ACCESS", False)
+    def CORS_ALLOW_PRIVATE_NETWORK(self) -> bool:
+        return getattr(settings, "CORS_ALLOW_PRIVATE_NETWORK", False)
 
     @property
     def CORS_PREFLIGHT_MAX_AGE(self) -> int:

--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -132,7 +132,7 @@ class CorsMiddleware:
                 response[ACCESS_CONTROL_MAX_AGE] = str(conf.CORS_PREFLIGHT_MAX_AGE)
 
         if (
-            conf.CORS_ALLOW_PRIVATE_NETWORK_ACCESS
+            conf.CORS_ALLOW_PRIVATE_NETWORK
             and request.headers.get(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK) == "true"
         ):
             response[ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK] = "true"

--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -21,6 +21,8 @@ ACCESS_CONTROL_ALLOW_CREDENTIALS = "access-control-allow-credentials"
 ACCESS_CONTROL_ALLOW_HEADERS = "access-control-allow-headers"
 ACCESS_CONTROL_ALLOW_METHODS = "access-control-allow-methods"
 ACCESS_CONTROL_MAX_AGE = "access-control-max-age"
+ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = "access-control-request-private-network"
+ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = "access-control-allow-private-network"
 
 
 class CorsMiddleware:
@@ -128,6 +130,12 @@ class CorsMiddleware:
             response[ACCESS_CONTROL_ALLOW_METHODS] = ", ".join(conf.CORS_ALLOW_METHODS)
             if conf.CORS_PREFLIGHT_MAX_AGE:
                 response[ACCESS_CONTROL_MAX_AGE] = str(conf.CORS_PREFLIGHT_MAX_AGE)
+
+        if (
+            conf.CORS_ALLOW_PRIVATE_NETWORK_ACCESS
+            and request.headers.get(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK) == "true"
+        ):
+            response[ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK] = "true"
 
         return response
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -52,7 +52,7 @@ class ChecksTests(SimpleTestCase):
     def test_cors_allow_credentials_non_bool(self):
         self.check_error_codes(["corsheaders.E003"])
 
-    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=object)
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK=object)
     def test_cors_allow_network_access_non_bool(self):
         self.check_error_codes(["corsheaders.E015"])
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -52,6 +52,10 @@ class ChecksTests(SimpleTestCase):
     def test_cors_allow_credentials_non_bool(self):
         self.check_error_codes(["corsheaders.E003"])
 
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=object)
+    def test_cors_allow_network_access_non_bool(self):
+        self.check_error_codes(["corsheaders.E015"])
+
     @override_settings(CORS_PREFLIGHT_MAX_AGE="10")
     def test_cors_preflight_max_age_non_integer(self):
         self.check_error_codes(["corsheaders.E004"])

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -95,9 +95,7 @@ class CorsMiddlewareTests(TestCase):
         resp = self.client.get("/", HTTP_ORIGIN="https://example.com")
         assert ACCESS_CONTROL_ALLOW_CREDENTIALS not in resp
 
-    @override_settings(
-        CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=True
-    )
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK=True, CORS_ALLOW_ALL_ORIGINS=True)
     def test_allow_private_network_added_if_enabled_and_requested(self):
         resp = self.client.get(
             "/",
@@ -106,15 +104,13 @@ class CorsMiddlewareTests(TestCase):
         )
         assert resp[ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK] == "true"
 
-    @override_settings(
-        CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=True
-    )
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK=True, CORS_ALLOW_ALL_ORIGINS=True)
     def test_allow_private_network_not_added_if_enabled_and_not_requested(self):
         resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
 
     @override_settings(
-        CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True,
+        CORS_ALLOW_PRIVATE_NETWORK=True,
         CORS_ALLOWED_ORIGINS=["http://example.com"],
     )
     def test_allow_private_network_not_added_if_enabled_and_no_cors_origin(self):
@@ -125,9 +121,7 @@ class CorsMiddlewareTests(TestCase):
         )
         assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
 
-    @override_settings(
-        CORS_ALLOW_PRIVATE_NETWORK_ACCESS=False, CORS_ALLOW_ALL_ORIGINS=True
-    )
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK=False, CORS_ALLOW_ALL_ORIGINS=True)
     def test_allow_private_network_not_added_if_disabled_and_requested(self):
         resp = self.client.get(
             "/",

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -106,9 +106,9 @@ class CorsMiddlewareTests(TestCase):
         resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
 
-    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=False)
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOWED_ORIGINS=["http://example.com"])
     def test_allow_private_network_not_added_if_enabled_and_no_cors_origin(self):
-        resp = self.client.get("/", HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true", HTTP_ORIGIN="http://example.com")
+        resp = self.client.get("/", HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true", HTTP_ORIGIN="http://example.org")
         assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
 
     @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=False, CORS_ALLOW_ALL_ORIGINS=True)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -8,6 +8,8 @@ from django.test.utils import override_settings
 from django.utils.deprecation import MiddlewareMixin
 
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_CREDENTIALS
+from corsheaders.middleware import ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK
+from corsheaders.middleware import ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_HEADERS
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_METHODS
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_ORIGIN
@@ -93,6 +95,26 @@ class CorsMiddlewareTests(TestCase):
     def test_get_dont_allow_credentials(self):
         resp = self.client.get("/", HTTP_ORIGIN="https://example.com")
         assert ACCESS_CONTROL_ALLOW_CREDENTIALS not in resp
+
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=True)
+    def test_allow_private_network_added_if_enabled_and_requested(self):
+        resp = self.client.get("/", HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true", HTTP_ORIGIN="http://example.com")
+        assert resp[ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK] == "true"
+
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=True)
+    def test_allow_private_network_not_added_if_enabled_and_not_requested(self):
+        resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
+        assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
+
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=False)
+    def test_allow_private_network_not_added_if_enabled_and_no_cors_origin(self):
+        resp = self.client.get("/", HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true", HTTP_ORIGIN="http://example.com")
+        assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
+
+    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=False, CORS_ALLOW_ALL_ORIGINS=True)
+    def test_allow_private_network_not_added_if_disabled_and_requested(self):
+        resp = self.client.get("/", HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true", HTTP_ORIGIN="http://example.com")
+        assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
 
     @override_settings(
         CORS_ALLOW_HEADERS=["content-type"],

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -8,11 +8,10 @@ from django.test.utils import override_settings
 from django.utils.deprecation import MiddlewareMixin
 
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_CREDENTIALS
-from corsheaders.middleware import ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK
-from corsheaders.middleware import ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_HEADERS
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_METHODS
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_ORIGIN
+from corsheaders.middleware import ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK
 from corsheaders.middleware import ACCESS_CONTROL_EXPOSE_HEADERS
 from corsheaders.middleware import ACCESS_CONTROL_MAX_AGE
 from tests.utils import prepend_middleware
@@ -96,24 +95,45 @@ class CorsMiddlewareTests(TestCase):
         resp = self.client.get("/", HTTP_ORIGIN="https://example.com")
         assert ACCESS_CONTROL_ALLOW_CREDENTIALS not in resp
 
-    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=True)
+    @override_settings(
+        CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=True
+    )
     def test_allow_private_network_added_if_enabled_and_requested(self):
-        resp = self.client.get("/", HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true", HTTP_ORIGIN="http://example.com")
+        resp = self.client.get(
+            "/",
+            HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true",
+            HTTP_ORIGIN="http://example.com",
+        )
         assert resp[ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK] == "true"
 
-    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=True)
+    @override_settings(
+        CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOW_ALL_ORIGINS=True
+    )
     def test_allow_private_network_not_added_if_enabled_and_not_requested(self):
         resp = self.client.get("/", HTTP_ORIGIN="http://example.com")
         assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
 
-    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True, CORS_ALLOWED_ORIGINS=["http://example.com"])
+    @override_settings(
+        CORS_ALLOW_PRIVATE_NETWORK_ACCESS=True,
+        CORS_ALLOWED_ORIGINS=["http://example.com"],
+    )
     def test_allow_private_network_not_added_if_enabled_and_no_cors_origin(self):
-        resp = self.client.get("/", HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true", HTTP_ORIGIN="http://example.org")
+        resp = self.client.get(
+            "/",
+            HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true",
+            HTTP_ORIGIN="http://example.org",
+        )
         assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
 
-    @override_settings(CORS_ALLOW_PRIVATE_NETWORK_ACCESS=False, CORS_ALLOW_ALL_ORIGINS=True)
+    @override_settings(
+        CORS_ALLOW_PRIVATE_NETWORK_ACCESS=False, CORS_ALLOW_ALL_ORIGINS=True
+    )
     def test_allow_private_network_not_added_if_disabled_and_requested(self):
-        resp = self.client.get("/", HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true", HTTP_ORIGIN="http://example.com")
+        resp = self.client.get(
+            "/",
+            HTTP_ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK="true",
+            HTTP_ORIGIN="http://example.com",
+        )
         assert ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK not in resp
 
     @override_settings(


### PR DESCRIPTION
This PR adds support for private network access. The feature was already added in PR #745, but unfortunately it hasn’t been merged yet. This PR builds on #745 but addresses the review comments in the original PR.
Details about private network access can be found [here on the Chrome blog](https://developer.chrome.com/blog/private-network-access-preflight/). The original release plan is to enforce private network access in version 111 (at the earliest), which is the next version to be released.

According to the [implementation status](https://chromestatus.com/feature/5737414355058688), the feature might land in Chrome 113.