### PR TITLE
Fix private network setitng name in CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 4.0.0 (2023-05-12)
 ------------------
 
-* Add ``CORS_ALLOW_PRIVATE_NETWORK_ACCESS`` setting, which enables support for the Local Network Access draft specification.
+* Add ``CORS_ALLOW_PRIVATE_NETWORK`` setting, which enables support for the Local Network Access draft specification.
 
   Thanks to Issac Kelly in `PR #745 <https://github.com/adamchainz/django-cors-headers/pull/745>`__ and jjurgens0 in `PR #833 <https://github.com/adamchainz/django-cors-headers/pull/833>`__.
 


### PR DESCRIPTION
I was checking the changelogs of `django-cors-headers@v4` when I couldn't find any source code referencing the `CORS_ALLOW_PRIVATE_NETWORK_ACCESS` setting mentioned in `CHANGELOG.rst`.

I believe it was intended to be `CORS_ALLOW_PRIVATE_NETWORK` instead. Proposing updating the changelog to avoid confusion to others who might also upgrade to `v4`.

Ref:
https://github.com/adamchainz/django-cors-headers/pull/833/files