### PR TITLE
Move stray comment

### DIFF
--- a/src/corsheaders/conf.py
+++ b/src/corsheaders/conf.py
@@ -12,8 +12,6 @@ from django.conf import settings
 from corsheaders.defaults import default_headers
 from corsheaders.defaults import default_methods
 
-# Kept here for backwards compatibility
-
 
 class Settings:
     """

--- a/src/corsheaders/defaults.py
+++ b/src/corsheaders/defaults.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# Kept here for backwards compatibility
+
 default_headers = (
     "accept",
     "authorization",


### PR DESCRIPTION
Seems that this comment was moved to a somewhat random position after automated code cleanup, moved it back to where it was before.

See:
https://github.com/adamchainz/django-cors-headers/commit/c171a32794f932769c826fafaf91cc90ab30d0d2#diff-db31a113ed29f9d863809faac07a22adef130103b150b1305b53756baa398d6f