### PR TITLE
Add license information to project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires = [
 name = "django-cors-headers"
 version = "4.4.0"
 description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
-license = "MIT"
 readme = "README.rst"
 keywords = [
   "api",
@@ -17,6 +16,7 @@ keywords = [
   "middleware",
   "rest",
 ]
+license = "MIT"
 maintainers = [
   { name = "Adam Johnson", email = "me@adamj.eu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
   "middleware",
   "rest",
 ]
-license = "MIT"
+license = { text = "MIT" }
 maintainers = [
   { name = "Adam Johnson", email = "me@adamj.eu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
 name = "django-cors-headers"
 version = "4.4.0"
 description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
+license = "MIT"
 readme = "README.rst"
 keywords = [
   "api",


### PR DESCRIPTION
License scanning tools (such as the one used by GitLab) rely on the project metadata (made available via the PyPi API) to detect the license for a package.

Currently, `license: null` is returned.

This PR adds the license to the project metadata.