### PR TITLE
Add CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES setting for PascalCase headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+4.7.1 (2025-02-25)
+* Add ``CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES`` setting to allow returning CORS headers in PascalCase format.
+  (`RFC 7230 Section 3.2 <https://datatracker.ietf.org/doc/html/rfc7230#section-3.2>`_)
+
 4.7.0 (2025-02-06)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -310,6 +310,22 @@ Refer to:
 * `Local Network Access <https://wicg.github.io/local-network-access/>`__, the W3C Community Draft specification.
 * `Private Network Access: introducing preflights <https://developer.chrome.com/blog/private-network-access-preflight/>`__, a blog post from the Google Chrome team.
 
+``CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES: bool``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If ``True``, the CORS response headers will use PascalCase format (e.g. ``Access-Control-Allow-Origin``) 
+instead of the default lowercase format (e.g. ``access-control-allow-origin``).
+Defaults to ``False``.
+
+Both formats are valid according to (`RFC 7230 Section 3.2 <https://datatracker.ietf.org/doc/html/rfc7230#section-3.2>`_). Some legacy systems may expect a specific format,
+so this setting allows you to match their requirements.
+
+Example:
+
+.. code-block:: python
+
+    CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES = True
+
 CSRF Integration
 ----------------
 

--- a/README.rst
+++ b/README.rst
@@ -313,7 +313,7 @@ Refer to:
 ``CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES: bool``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If ``True``, the CORS response headers will use PascalCase format (e.g. ``Access-Control-Allow-Origin``) 
+If ``True``, the CORS response headers will use PascalCase format (e.g. ``Access-Control-Allow-Origin``)
 instead of the default lowercase format (e.g. ``access-control-allow-origin``).
 Defaults to ``False``.
 

--- a/src/corsheaders/checks.py
+++ b/src/corsheaders/checks.py
@@ -50,6 +50,7 @@ def check_settings(**kwargs: Any) -> list[CheckMessage]:
         not isinstance(conf.CORS_PREFLIGHT_MAX_AGE, int)  # type: ignore [redundant-expr]
         or conf.CORS_PREFLIGHT_MAX_AGE < 0
     ):
+
         errors.append(
             Error(
                 (
@@ -166,6 +167,14 @@ def check_settings(**kwargs: Any) -> list[CheckMessage]:
                     + " - see django-cors-headers' CHANGELOG."
                 ),
                 id="corsheaders.E013",
+            )
+        )
+
+    if not isinstance(conf.USE_PASCAL_CASE_FOR_HEADER_NAMES, bool):
+        errors.append(
+            Error(
+                "CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES should be a bool.",
+                id="corsheaders.E016",
             )
         )
 

--- a/src/corsheaders/conf.py
+++ b/src/corsheaders/conf.py
@@ -69,5 +69,9 @@ class Settings:
     def CORS_URLS_REGEX(self) -> str | Pattern[str]:
         return getattr(settings, "CORS_URLS_REGEX", r"^.*$")
 
+    @property
+    def USE_PASCAL_CASE_FOR_HEADER_NAMES(self) -> bool:
+        return getattr(settings, "CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES", False)
+
 
 conf = Settings()

--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -16,14 +16,43 @@ from django.utils.cache import patch_vary_headers
 from corsheaders.conf import conf
 from corsheaders.signals import check_request_enabled
 
-ACCESS_CONTROL_ALLOW_ORIGIN = "access-control-allow-origin"
-ACCESS_CONTROL_EXPOSE_HEADERS = "access-control-expose-headers"
-ACCESS_CONTROL_ALLOW_CREDENTIALS = "access-control-allow-credentials"
-ACCESS_CONTROL_ALLOW_HEADERS = "access-control-allow-headers"
-ACCESS_CONTROL_ALLOW_METHODS = "access-control-allow-methods"
-ACCESS_CONTROL_MAX_AGE = "access-control-max-age"
-ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = "access-control-request-private-network"
-ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = "access-control-allow-private-network"
+# Define both variants of headers
+_HEADERS_LOWER = {
+    "access-control-allow-origin": "access-control-allow-origin",
+    "access-control-expose-headers": "access-control-expose-headers",
+    "access-control-allow-credentials": "access-control-allow-credentials",
+    "access-control-allow-headers": "access-control-allow-headers",
+    "access-control-allow-methods": "access-control-allow-methods",
+    "access-control-max-age": "access-control-max-age",
+    "access-control-request-private-network": "access-control-request-private-network",
+    "access-control-allow-private-network": "access-control-allow-private-network",
+}
+
+_HEADERS_PASCAL = {
+    "access-control-allow-origin": "Access-Control-Allow-Origin",
+    "access-control-expose-headers": "Access-Control-Expose-Headers", 
+    "access-control-allow-credentials": "Access-Control-Allow-Credentials",
+    "access-control-allow-headers": "Access-Control-Allow-Headers",
+    "access-control-allow-methods": "Access-Control-Allow-Methods",
+    "access-control-max-age": "Access-Control-Max-Age",
+    "access-control-request-private-network": "Access-Control-Request-Private-Network",
+    "access-control-allow-private-network": "Access-Control-Allow-Private-Network",
+}
+
+# Use PascalCase or lowercase based on setting
+def get_header_name(header_key: str) -> str:
+    if conf.USE_PASCAL_CASE_FOR_HEADER_NAMES:
+        return _HEADERS_PASCAL[header_key]
+    return _HEADERS_LOWER[header_key]
+
+ACCESS_CONTROL_ALLOW_ORIGIN = get_header_name("access-control-allow-origin")
+ACCESS_CONTROL_EXPOSE_HEADERS = get_header_name("access-control-expose-headers")
+ACCESS_CONTROL_ALLOW_CREDENTIALS = get_header_name("access-control-allow-credentials")
+ACCESS_CONTROL_ALLOW_HEADERS = get_header_name("access-control-allow-headers") 
+ACCESS_CONTROL_ALLOW_METHODS = get_header_name("access-control-allow-methods")
+ACCESS_CONTROL_MAX_AGE = get_header_name("access-control-max-age")
+ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = get_header_name("access-control-request-private-network")
+ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = get_header_name("access-control-allow-private-network")
 
 
 class CorsMiddleware:

--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -30,7 +30,7 @@ _HEADERS_LOWER = {
 
 _HEADERS_PASCAL = {
     "access-control-allow-origin": "Access-Control-Allow-Origin",
-    "access-control-expose-headers": "Access-Control-Expose-Headers", 
+    "access-control-expose-headers": "Access-Control-Expose-Headers",
     "access-control-allow-credentials": "Access-Control-Allow-Credentials",
     "access-control-allow-headers": "Access-Control-Allow-Headers",
     "access-control-allow-methods": "Access-Control-Allow-Methods",
@@ -39,20 +39,26 @@ _HEADERS_PASCAL = {
     "access-control-allow-private-network": "Access-Control-Allow-Private-Network",
 }
 
+
 # Use PascalCase or lowercase based on setting
 def get_header_name(header_key: str) -> str:
     if conf.USE_PASCAL_CASE_FOR_HEADER_NAMES:
         return _HEADERS_PASCAL[header_key]
     return _HEADERS_LOWER[header_key]
 
+
 ACCESS_CONTROL_ALLOW_ORIGIN = get_header_name("access-control-allow-origin")
 ACCESS_CONTROL_EXPOSE_HEADERS = get_header_name("access-control-expose-headers")
 ACCESS_CONTROL_ALLOW_CREDENTIALS = get_header_name("access-control-allow-credentials")
-ACCESS_CONTROL_ALLOW_HEADERS = get_header_name("access-control-allow-headers") 
+ACCESS_CONTROL_ALLOW_HEADERS = get_header_name("access-control-allow-headers")
 ACCESS_CONTROL_ALLOW_METHODS = get_header_name("access-control-allow-methods")
 ACCESS_CONTROL_MAX_AGE = get_header_name("access-control-max-age")
-ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = get_header_name("access-control-request-private-network")
-ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = get_header_name("access-control-allow-private-network")
+ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = get_header_name(
+    "access-control-request-private-network"
+)
+ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = get_header_name(
+    "access-control-allow-private-network"
+)
 
 
 class CorsMiddleware:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -41,7 +41,7 @@ class ConfTests(SimpleTestCase):
     )
     def test_cors_allowed_origin_regexes_new_setting_takes_precedence(self):
         assert conf.CORS_ALLOWED_ORIGIN_REGEXES == ["a+"]
-        
+
     @override_settings()
     def test_default_pascal_case_headers_setting(self):
         """Test that USE_PASCAL_CASE_FOR_HEADER_NAMES defaults to False when not set"""
@@ -52,7 +52,7 @@ class ConfTests(SimpleTestCase):
         """Test that None value for USE_PASCAL_CASE_FOR_HEADER_NAMES defaults to False"""
         assert conf.USE_PASCAL_CASE_FOR_HEADER_NAMES is False
 
-    @override_settings(CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES=True) 
+    @override_settings(CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES=True)
     def test_invalid_pascal_case_headers_setting(self):
         """Test that non-boolean value does not affect the default"""
         assert conf.USE_PASCAL_CASE_FOR_HEADER_NAMES is False

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -41,3 +41,18 @@ class ConfTests(SimpleTestCase):
     )
     def test_cors_allowed_origin_regexes_new_setting_takes_precedence(self):
         assert conf.CORS_ALLOWED_ORIGIN_REGEXES == ["a+"]
+        
+    @override_settings()
+    def test_default_pascal_case_headers_setting(self):
+        """Test that USE_PASCAL_CASE_FOR_HEADER_NAMES defaults to False when not set"""
+        assert conf.USE_PASCAL_CASE_FOR_HEADER_NAMES is False
+
+    @override_settings(CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES=None)
+    def test_none_pascal_case_headers_setting(self):
+        """Test that None value for USE_PASCAL_CASE_FOR_HEADER_NAMES defaults to False"""
+        assert conf.USE_PASCAL_CASE_FOR_HEADER_NAMES is False
+
+    @override_settings(CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES=True) 
+    def test_invalid_pascal_case_headers_setting(self):
+        """Test that non-boolean value does not affect the default"""
+        assert conf.USE_PASCAL_CASE_FOR_HEADER_NAMES is False

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -464,3 +464,13 @@ class CorsMiddlewareTests(TestCase):
             "/delete-enabled/", headers={"origin": "https://example.com"}
         )
         assert ACCESS_CONTROL_ALLOW_ORIGIN in resp
+
+    @override_settings(
+        CORS_ALLOWED_ORIGINS=["https://example.com"],
+        CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES=True,
+    )
+    def test_pascal_case_headers(self):
+        resp = self.client.get("/", headers={"origin": "https://example.com"})
+        assert "Access-Control-Allow-Origin" in resp
+        assert "access-control-allow-origin" not in resp
+        assert resp["Access-Control-Allow-Origin"] == "https://example.com"


### PR DESCRIPTION
This pull request introduces a new setting, `CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES`, to allow CORS headers to be returned in PascalCase format. 

Configuration and middleware updates:

* Added a property to `Settings` in `src/corsheaders/conf.py` to get the value of `CORS_USE_PASCAL_CASE_FOR_HEADER_NAMES`.
* Updated `src/corsheaders/middleware.py` to define both lowercase and PascalCase versions of headers and use the appropriate format based on the new setting.

This links to the issue: #993 