### PR TITLE
Refs #1043: pass request to origin whitelist checks

### DIFF
--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Awaitable, Callable
+from typing import Optional
 from urllib.parse import SplitResult, urlsplit
 
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
@@ -103,7 +104,7 @@ class CorsMiddleware:
 
         if (
             not conf.CORS_ALLOW_ALL_ORIGINS
-            and not self.origin_found_in_white_lists(origin, url)
+            and not self.origin_found_in_white_lists(origin, url, request)
             and not self.check_signal(request)
         ):
             return response
@@ -135,7 +136,13 @@ class CorsMiddleware:
 
         return response
 
-    def origin_found_in_white_lists(self, origin: str, url: SplitResult) -> bool:
+    def origin_found_in_white_lists(
+            self,
+            origin: str,
+            url: SplitResult,
+            request: Optional[HttpRequest] = None
+        ) -> bool:
+
         return (
             (origin == "null" and origin in conf.CORS_ALLOWED_ORIGINS)
             or self._url_in_whitelist(url)

--- a/src/corsheaders/middleware.py
+++ b/src/corsheaders/middleware.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from collections.abc import Awaitable, Callable
-from typing import Optional
 from urllib.parse import SplitResult, urlsplit
 
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
@@ -137,11 +136,8 @@ class CorsMiddleware:
         return response
 
     def origin_found_in_white_lists(
-            self,
-            origin: str,
-            url: SplitResult,
-            request: Optional[HttpRequest] = None
-        ) -> bool:
+        self, origin: str, url: SplitResult, request: HttpRequest | None = None
+    ) -> bool:
 
         return (
             (origin == "null" and origin in conf.CORS_ALLOWED_ORIGINS)


### PR DESCRIPTION
Problem

origin_found_in_white_lists() cannot perform path-aware origin decisions because request context is unavailable.

Solution

Pass request as first argument while preserving backward compatibility.