### PR TITLE
Faster default regexp for matching requests.

### DIFF
--- a/src/corsheaders/conf.py
+++ b/src/corsheaders/conf.py
@@ -65,7 +65,7 @@ class Settings:
 
     @property
     def CORS_URLS_REGEX(self) -> str | Pattern[str]:
-        return getattr(settings, "CORS_URLS_REGEX", r"^.*$")
+        return getattr(settings, "CORS_URLS_REGEX", "")
 
 
 conf = Settings()


### PR DESCRIPTION
Hello,
The default value of this regexp is used just to match any incoming request. Matched value is never used.

Empty regexp serves this purpose just as well (matches any string) but is running roughly 2.3 times faster. It's a matter of hundreds of nanoseconds but is affecting every request.